### PR TITLE
Fixed Keyboard Navigation in closed state

### DIFF
--- a/jQuery.GI.TheWall.js
+++ b/jQuery.GI.TheWall.js
@@ -298,6 +298,8 @@
 
         _onKeypress = function (e) {
           if (!this.isOpened()) return;
+          if (e.target.form !== undefined) return;
+          if (e.target.isContentEditable) return;
           if ($.inArray(e.keyCode, keyboardKeys) > -1) {
             e.preventDefault();
           }


### PR DESCRIPTION
Allows Navigation of Webcontent with Keyboard while the expander isn't open.
Also added a check if the event target is contentEditable or part a form element while the expander is opened
