### PR TITLE
Closing issue on touch devices and video integrated function

### DIFF
--- a/jQuery.GI.TheWall.js
+++ b/jQuery.GI.TheWall.js
@@ -246,6 +246,19 @@
           img.src = src;
           return dfr.promise();
         },
+		/**
+		 * Load youtube video inside the extender inner wrapper
+		 * @param  { String } videoUrl: video url
+		 * @return { Object } jquery deferred object
+		 */
+		_loadVideo = function (videoUrl) {
+			var dfr = new $.Deferred();
+
+			self.$expanderInner.html('<div class="GI_TW_fullimg"><iframe src="' + videoUrl + '"></iframe></div>');
+			dfr.resolve();
+
+			return dfr.promise();
+		},
         /**
          * Load html contents inside the extender inner wrapper via ajax
          * @param  { String } href: contents url
@@ -442,6 +455,9 @@
           case 'inline':
             callback = _loadInlineContent(href);
             break;
+		  case 'video':
+			callback = _loadVideo(href);
+	  		break;
           default:
             callback = _loadImage(href);
             break;

--- a/jQuery.GI.TheWall.js
+++ b/jQuery.GI.TheWall.js
@@ -90,7 +90,7 @@
         cachedWrapperHeight = 0,
         eventsNamespace = '.GITheWall' + GI_TW_ID,
         eventsNames = {
-          click: istouch ? "touchstart" : "click",
+          click: istouch ? "touchend" : "click",
           mousedown: istouch ? "touchstart" : "mousedown",
           mouseup: istouch ? "touchend" : "mouseup",
           mousemove: istouch ? "touchmove" : "mousemove",

--- a/jQuery.GI.TheWall.js
+++ b/jQuery.GI.TheWall.js
@@ -497,7 +497,8 @@
       /**
        * Hide the expander cleaning its inner html
        */
-      this.hideExpander = function () {
+      this.hideExpander = function (e) {
+		e.preventDefault();
         this.$expanderWrapper.removeClass('opened').stop(true, false)[csstransitions ? 'css' : 'animate']({
           'height': 0
         }, options.animationSpeed);


### PR DESCRIPTION
If the close button is in the same alignment as the small pictures it opens the small image which is located behind the close button. Issue on touch devices.
